### PR TITLE
fix collection of component-level datasources

### DIFF
--- a/ZenPacks/zenoss/HttpMonitor/datasources/HttpMonitorDataSource.py
+++ b/ZenPacks/zenoss/HttpMonitor/datasources/HttpMonitorDataSource.py
@@ -189,7 +189,7 @@ class HttpMonitorDataSourcePlugin(PythonDataSourcePlugin):
 
         for dp in ds0.points:
             if dp.id in perfData:
-                data['values'][None][dp.id] = perfData[dp.id]
+                data['values'][ds0.component][dp.id] = perfData[dp.id]
 
         eventKey = ds0.eventKey or 'HttpMonitor'
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -278,10 +278,12 @@ Daemons
 
 Changes
 -------
+
 3.0.5
 - Fix infinity redirection in the case with not full URI path in header Location (ZPS-4904
 - Fix issue when HTTPMonitor doesn't check response and doesn't handle either (ZPS-4998)
 - Fix crashes of PythonCollector in the case with blank IP Address or Proxy Address fields (ZPS-4986)
+- Fix collection of datapoints for component-level datasources (ZPS-5550)
 
 
 3.0.4


### PR DESCRIPTION
The component portion of data["values"] was being hard-coded to None,
which means the metrics are always associated to the device. This update
appropriate uses the datasource's component configuration so that
device-level datasources collect to the device, and component-level
datasources collect to the appropriate component.

Fixes ZPS-5550.