### PR TITLE
Improve fallback value

### DIFF
--- a/ZenPacks/zenoss/HttpMonitor/datasources/HttpMonitorDataSource.py
+++ b/ZenPacks/zenoss/HttpMonitor/datasources/HttpMonitorDataSource.py
@@ -99,10 +99,10 @@ class HttpMonitorDataSourcePlugin(PythonDataSourcePlugin):
 
         # Check zHttpMonitorDataSourceSettings zProp. If it is 'enabled' - take values from it.
         # Fall back to default if particular setting is missed in this config.
-        z_settings_string = getattr(context, 'zHttpMonitorDataSourceSettings', '')
+        z_settings_string = getattr(context, 'zHttpMonitorDataSourceSettings', 'enabled: false')
 
         try:
-            z_settings = yaml.load(z_settings_string, Loader=yaml.CLoader)
+            z_settings = yaml.safe_load(z_settings_string)
         except Exception:
             z_settings = {}
         if z_settings.get('enabled'):


### PR DESCRIPTION
Fixes ZPS-8234.

* Improve fallback value while checking zHttpMonitorDataSourceSettings property. Currently empty string is parsed as Null, that isn't correct.
* Use more general yaml.safe_load to be compatible with new and previous PyYaml versions.